### PR TITLE
Fix proxy in arguments different from environment variable

### DIFF
--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -56,7 +56,7 @@ class API
     end
 
     @http_proxy = opts[:http_proxy] || ENV['HTTP_PROXY']
-    if @http_proxy = ENV['HTTP_PROXY']
+    if @http_proxy
       if @http_proxy =~ /\Ahttp:\/\/(.*)\z/
         @http_proxy = $~[1]
       end


### PR DESCRIPTION
環境変数が設定されていない時にhttp_proxyを指定してもプロキシを経由するように修正しました。
