### PR TITLE
Use elapsed_time field instead of time in import method

### DIFF
--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -889,7 +889,7 @@ class API
       raise_error("Import failed", res)
     end
     js = checked_json(body, %w[])
-    time = js['time'].to_f
+    time = js['elapsed_time'].to_f
     return time
   end
 


### PR DESCRIPTION
API response contains `elapsed_time`, not `time` field.
Maybe `time` field is outdated.
