### PR TITLE
spec updates

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,12 +25,12 @@ shared_context 'common helper' do
   end
 
   let :headers do
-    {'Accept' => '*/*', 'Accept-Encoding' => 'deflate, gzip', 'Date' => /.*/, 'User-Agent' => 'Ruby'}
+    {'Accept' => '*/*', 'Accept-Encoding' => /gzip/, 'Date' => /.*/, 'User-Agent' => /Ruby/}
   end
 
   def stub_api_request(method, path, opts = nil)
     scheme = 'http'
-    with_opts = {:header => headers}
+    with_opts = {:headers => headers}
     if opts
       scheme = 'https' if opts[:ssl]
       with_opts[:query] = opts[:query] if opts[:query]

--- a/spec/td/client/db_api_spec.rb
+++ b/spec/td/client/db_api_spec.rb
@@ -18,7 +18,7 @@ describe 'Database API' do
       stub_api_request(:post, "/v3/database/create/#{e(db_name)}")
         .to_return(:body => {'database' => db_name}.to_json)
 
-      api.create_database(db_name).should be_true
+      api.create_database(db_name).should be true
     end
 
     it 'should return 400 error with invalid name' do

--- a/spec/td/client/job_api_spec.rb
+++ b/spec/td/client/job_api_spec.rb
@@ -18,7 +18,6 @@ describe 'Job API' do
     it 'should returns 20 jobs by default' do
       stub_api_request(:get, "/v3/job/list", :query => {'from' => '0'}).to_return(:body => {'jobs' => raw_jobs}.to_json)
       jobs = api.list_jobs
-      puts jobs.size
       jobs.size.should == 20
     end
 

--- a/spec/td/client/result_api_spec.rb
+++ b/spec/td/client/result_api_spec.rb
@@ -14,7 +14,7 @@ describe 'Result API' do
       params = {'url' => result_url}
       stub_api_request(:post, "/v3/result/create/#{e(result_name)}").with(:body => params).to_return(:body => {'result' => result_name})
 
-      api.create_result(result_name, result_url).should be_true
+      api.create_result(result_name, result_url).should be true
     end
 
     it 'should return 422 error with invalid name' do

--- a/spec/td/client/sched_api_spec.rb
+++ b/spec/td/client/sched_api_spec.rb
@@ -17,21 +17,21 @@ describe 'Schedule API' do
     it 'should create a new schedule' do
       start = Time.now
       stub_api_request(:post, "/v3/schedule/create/#{e(sched_name)}")
-        .with(opts.merge('type' => 'hive'))
+        .with(:body => opts.merge('type' => 'hive'))
         .to_return(:body => {'name' => sched_name, 'start' => start.to_s}.to_json)
 
-      api.create_schedule(sched_name, opts).should == start.to_s
+      api.create_schedule(sched_name, opts.merge('type' => 'hive')).should == start.to_s
     end
 
     it 'should return 422 error with invalid name' do
       name = '1'
       err_msg = "Validation failed: Name is too short" # " (minimum is 3 characters)"
       stub_api_request(:post, "/v3/schedule/create/#{e(name)}")
-        .with(opts.merge('type' => 'hive'))
+        .with(:body => opts.merge('type' => 'hive'))
         .to_return(:status => 422, :body => {'message' => err_msg}.to_json)
 
       expect {
-        api.create_schedule(name, opts)
+        api.create_schedule(name, opts.merge('type' => 'hive'))
       }.to raise_error(TreasureData::APIError, /#{err_msg}/)
     end
   end
@@ -46,18 +46,17 @@ describe 'Schedule API' do
 
     it 'should not return 414 even if the query text is very long' do
       stub_api_request(:post, "/v3/schedule/update/#{e(sched_name)}")
-        .with(opts.merge('type' => 'pig'))
+        .with(:body => opts.merge('type' => 'pig'))
         .to_return(:body => {'name' => sched_name, 'query' => pig_query}.to_json)
 
-      err_msg = "Update schedule failed: Request-URI Too Long"
       expect {
-        api.update_schedule(sched_name, opts)
+        api.update_schedule(sched_name, opts.merge('type' => 'pig'))
       }.not_to raise_error
     end
 
     it 'should update the schedule with the new query' do
       stub_api_request(:post, "/v3/schedule/update/#{e(sched_name)}")
-        .with(opts.merge('type' => 'pig'))
+        .with(:body => opts.merge('type' => 'pig'))
         .to_return(:body => {'name' => sched_name, 'query' => pig_query}.to_json)
 
       stub_api_request(:get, "/v3/schedule/list")

--- a/spec/td/client/table_api_spec.rb
+++ b/spec/td/client/table_api_spec.rb
@@ -27,7 +27,7 @@ describe 'Table API' do
     it 'should create a new table if the database exists' do
       stub_api_request(:post, "/v3/table/create/#{e db_name}/#{e(table_name)}/log")
         .to_return(:body => {'database' => db_name, 'table' => table_name, 'type' => 'log'}.to_json)
-      api.create_log_table(db_name, table_name).should be_true
+      api.create_log_table(db_name, table_name).should be true
     end
 
     it 'should return 400 error with invalid name' do


### PR DESCRIPTION
- check HTTP request headers and body properly; upgrading webmock to
  1.19.0 caused errors (3F)
- vanish rspec deprecation warning on 'be_true'

@mcaramello 
