### PR TITLE
Allow httpclient version >= 2.5

### DIFF
--- a/td-client.gemspec
+++ b/td-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "< 0.6.0"]
   gem.add_dependency "json", ">= 1.7.6"
-  gem.add_dependency "httpclient", "~> 2.4.0"
+  gem.add_dependency "httpclient", [">= 2.4.0", "< 2.6.0"]
   gem.add_development_dependency "rspec", "~> 2.8"
   gem.add_development_dependency "webmock", "~> 1.16"
   gem.add_development_dependency 'simplecov', '>= 0.5.4'


### PR DESCRIPTION
Hi!

I want to use httpclient version >= 2.5 with td-client, which is safer version.

Thanks for great gem!