### PR TITLE
bump httpclient to latest minor version

### DIFF
--- a/td-client.gemspec
+++ b/td-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "< 0.6.0"]
   gem.add_dependency "json", ">= 1.7.6"
-  gem.add_dependency "httpclient", [">= 2.4.0", "< 2.6.0"]
+  gem.add_dependency "httpclient", ">= 2.6.0"
   gem.add_development_dependency "rspec", "~> 2.8"
   gem.add_development_dependency 'mime-types', "1.25" # mime-types => 2.0, does not support Ruby 1.8.
   gem.add_development_dependency 'rest-client', "1.6.8" # rest-client => 1.6.8, does not support Ruby 1.8.


### PR DESCRIPTION
fix #46 

Current httpclient version is 2.6. So, use 2.6.