### PR TITLE
reduce useless extend code

### DIFF
--- a/lib/td/client/api/job.rb
+++ b/lib/td/client/api/job.rb
@@ -150,14 +150,18 @@ module Job
           end
         end
 
-        total_compr_size = 0
-        res.each_fragment {|fragment|
-          total_compr_size += fragment.size
-          # uncompressed if the 'Content-Enconding' header is set in response
-          fragment = infl.inflate(fragment) if ce
-          io.write(fragment)
-          block.call(total_compr_size) if block_given?
-        }
+        begin
+          total_compr_size = 0
+          res.each_fragment {|fragment|
+            total_compr_size += fragment.size
+            # uncompressed if the 'Content-Enconding' header is set in response
+            fragment = infl.inflate(fragment) if ce
+            io.write(fragment)
+            block.call(total_compr_size) if block_given?
+          }
+        ensure
+          infl.close if infl
+        end
       }
       nil
     else

--- a/lib/td/client/api/job.rb
+++ b/lib/td/client/api/job.rb
@@ -140,14 +140,8 @@ module Job
           raise_error("Get job result failed", res)
         end
 
-        if ce = res.header['Content-Encoding']
-          res.extend(DeflateReadBodyMixin)
-          res.gzip = true if ce == 'gzip'
-        else
-          res.extend(DirectReadBodyMixin)
-        end
-
         res.extend(DirectReadBodyMixin)
+
         if ce = res.header['Content-Encoding']
           if ce == 'gzip'
             infl = Zlib::Inflate.new(Zlib::MAX_WBITS + 16)


### PR DESCRIPTION
[DeflateReadBodyMixin#each_fragment](https://github.com/treasure-data/td-client-ruby/blob/master/lib/td/client/api.rb#L246) is overwritten by extend [DirectReadBodyMixin](https://github.com/treasure-data/td-client-ruby/blob/master/lib/td/client/api.rb#L265) (l143).
And, we can't use DeflateReadBodyMixin#each_fragment. Because we need compressed fragment size.