### PR TITLE
retriable if content length missmatched

### DIFF
--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -42,7 +42,7 @@ class API
   NEW_DEFAULT_ENDPOINT = 'api.treasuredata.com'
   NEW_DEFAULT_IMPORT_ENDPOINT = 'api-import.treasuredata.com'
 
-  class IncompleteError < RuntimeError; end
+  class IncompleteError < APIError; end
 
   # @param [String] apikey
   # @param [Hash] opts

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -379,7 +379,7 @@ private
   end
 
   def completed_body?(response)
-    # NOTE If response isn't have content_length, we are assumed success.
+    # NOTE If response doesn't have content_length, we assume it succeeds.
     return true unless (content_length = response.header.content_length)
 
     content_length == response.body.length

--- a/lib/td/client/api/job.rb
+++ b/lib/td/client/api/job.rb
@@ -156,13 +156,11 @@ module Job
           end
         end
 
-        total_compr_size = 0
         res.each_fragment {|fragment|
-          total_compr_size += fragment.size
           # uncompressed if the 'Content-Enconding' header is set in response
           fragment = infl.inflate(fragment) if ce
           io.write(fragment)
-          block.call(total_compr_size) if block_given?
+          block.call(res.total_fragment_size) if block_given?
         }
       }
       nil
@@ -216,11 +214,9 @@ module Job
       end
       upkr = MessagePack::Unpacker.new
       begin
-        total_compr_size = 0
         res.each_fragment {|fragment|
-          total_compr_size += fragment.size
           upkr.feed_each(infl.inflate(fragment)) {|unpacked|
-            block.call(unpacked, total_compr_size) if block_given?
+            block.call(unpacked, res.total_fragment_size) if block_given?
           }
         }
       ensure
@@ -244,11 +240,9 @@ module Job
       if io
         res.extend(DirectReadBodyMixin)
 
-        total_compr_size = 0
         res.each_fragment {|fragment|
-          total_compr_size += fragment.size
           io.write(fragment)
-          block.call(total_compr_size) if block_given?
+          block.call(res.total_fragment_size) if block_given?
         }
       else
         body = res.read_body

--- a/spec/td/client/api_http_access_spec.rb
+++ b/spec/td/client/api_http_access_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe API do
+  describe '#completed_body?' do
+    let(:api) { TreasureData::API.new('')  }
+    let(:response) { double(:response) }
+
+    subject { api.__send__(:completed_body?, response) }
+
+    context 'response has no content length' do
+      before do
+        response.stub_chain(:header, :content_length).and_return(nil)
+      end
+
+      it { is_expected.to be }
+    end
+
+    context 'response has content length' do
+      let(:content_length) { 10 }
+
+      before do
+        response.stub_chain(:header, :content_length).and_return(content_length)
+      end
+
+      context 'content length equal body size' do
+        before do
+          response.stub(:body).and_return('a' * content_length)
+        end
+
+        it { is_expected.to be }
+      end
+
+      context 'content length lager than body size' do
+        before do
+          response.stub(:body).and_return('a' * (content_length - 1))
+        end
+
+        it { is_expected.not_to be }
+      end
+
+      context 'content length less than body size' do
+        before do
+          response.stub(:body).and_return('a' * (content_length + 1))
+        end
+
+        it { is_expected.not_to be }
+      end
+    end
+  end
+end


### PR DESCRIPTION
It occures by combination OpenSSL raise EOFError and use
MessagePack::Unpacker.
Therefore, if the size of the body is less than the content length,
raise retryable error.