### PR TITLE
cosmetic error message

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_JOBS: 4

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -732,6 +732,7 @@ private
       when "403"
         ForbiddenError
       else
+        message = "#{status_code}: #{message}"
         APIError
       end
     end

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -709,17 +709,17 @@ private
     status_code = res.code.to_s
     error_msg = get_error(res)
     if klass
-      raise klass, "#{status_code}: #{msg}: #{res.body}"
+      raise klass, "#{status_code}: #{msg}: #{error_msg}"
     elsif status_code == "404"
-      raise NotFoundError, "#{msg}: #{res.body}"
+      raise NotFoundError, "#{msg}: #{error_msg}"
     elsif status_code == "409"
-      raise AlreadyExistsError, "#{msg}: #{res.body}"
+      raise AlreadyExistsError, "#{msg}: #{error_msg}"
     elsif status_code == "401"
-      raise AuthError, "#{msg}: #{res.body}"
+      raise AuthError, "#{msg}: #{error_msg}"
     elsif status_code == "403"
-      raise ForbiddenError, "#{msg}: #{res.body}"
+      raise ForbiddenError, "#{msg}: #{error_msg}"
     else
-      raise APIError, "#{status_code}: #{msg}: #{res.body}"
+      raise APIError, "#{status_code}: #{msg}: #{error_msg}"
     end
     # TODO error
   end

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -685,21 +685,29 @@ private
   # @param [response] res
   # @return [String]
   def get_error(res)
+    parse_error_response(res)['message']
+  end
+
+  def parse_error_response(res)
+    error = {}
+
     begin
       js = JSON.load(res.body)
       if js.nil?
-        error_msg = if res.respond_to?(:message)
+        error['message'] = if res.respond_to?(:message)
                       res.message # Net::HTTP
                     else
                       res.reason # HttpClient
                     end
       else
-        error_msg = js['message'] || js['error']
+        error['message']    = js['message'] || js['error']
+        error['stacktrace'] = js['stacktrace']
       end
     rescue JSON::ParserError
-      error_msg = res.body
+      error['message'] = res.body
     end
-    error_msg
+
+    error
   end
 
   # @param [String] msg
@@ -707,19 +715,19 @@ private
   # @param [Class] klass
   def raise_error(msg, res, klass=nil)
     status_code = res.code.to_s
-    error_msg = get_error(res)
+    error = parse_error_response(res)
     if klass
-      raise klass, "#{status_code}: #{msg}: #{error_msg}"
+      raise klass, "#{status_code}: #{msg}: #{error['message']}", error['stacktrace']
     elsif status_code == "404"
-      raise NotFoundError, "#{msg}: #{error_msg}"
+      raise NotFoundError.new("#{msg}: #{error['message']}", error['stacktrace'])
     elsif status_code == "409"
-      raise AlreadyExistsError, "#{msg}: #{error_msg}"
+      raise AlreadyExistsError.new("#{msg}: #{error['message']}", error['stacktrace'])
     elsif status_code == "401"
-      raise AuthError, "#{msg}: #{error_msg}"
+      raise AuthError.new("#{msg}: #{error['message']}", error['stacktrace'])
     elsif status_code == "403"
-      raise ForbiddenError, "#{msg}: #{error_msg}"
+      raise ForbiddenError.new("#{msg}: #{error['message']}", error['stacktrace'])
     else
-      raise APIError, "#{status_code}: #{msg}: #{error_msg}"
+      raise APIError.new("#{status_code}: #{msg}: #{error['message']}", error['stacktrace'])
     end
     # TODO error
   end

--- a/lib/td/client/api_error.rb
+++ b/lib/td/client/api_error.rb
@@ -5,6 +5,12 @@ end
 
 # Generic API error
 class APIError < StandardError
+  attr_reader :api_backtrace
+
+  def initialize(error_message = nil, api_backtrace = nil)
+    super(error_message)
+    @api_backtrace = api_backtrace == '' ? nil : api_backtrace
+  end
 end
 
 # 401 API errors


### PR DESCRIPTION
before : show full backtrace
after : only error message

```
### before
$ td connector:guess config/error_seed.yml
Error: 422: BulkLoad configuration guess failed: {"error":"org.embulk.exec.NoSampleException","message":"No input files to read sample data","stacktrace":"org.embulk.exec.NoSampleException: No input files to read sample data\n\tat org.embulk.exec.SamplingParserPlugin$1.run(SamplingParserPlugin.java:40)\n\tat org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:117)\n\tat org.embulk.exec.SamplingParserPlugin.transaction(SamplingParserPlugin.java:102)\n\tat org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:111)\n\tat org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:77)\n\tat org.embulk.spi.util.Decoders.transaction(Decoders.java:33)\n\tat org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:108)\n\tat org.embulk.input.s3.AbstractS3FileInputPlugin.resume(AbstractS3FileInputPlugin.java:102)\n\tat org.embulk.input.s3.AbstractS3FileInputPlugin.transaction(AbstractS3FileInputPlugin.java:89)\n\tat org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:63)\n\tat org.embulk.exec.SamplingParserPlugin.runFileInputSampling(SamplingParserPlugin.java:36)\n\tat org.embulk.spi.FileInputRunner.guess(FileInputRunner.java:78)\n\tat org.embulk.exec.GuessExecutor.doGuess(GuessExecutor.java:109)\n\tat org.embulk.exec.GuessExecutor.access$000(GuessExecutor.java:38)\n\tat org.embulk.exec.GuessExecutor$1.run(GuessExecutor.java:87)\n\tat org.embulk.exec.GuessExecutor$1.run(GuessExecutor.java:83)\n\tat org.embulk.spi.Exec.doWith(Exec.java:25)\n\tat org.embulk.exec.GuessExecutor.guess(GuessExecutor.java:83)\n\tat com.treasuredata.embulk.http.server.GuessService.doService(GuessService.java:33)\n\tat sun.reflect.GeneratedMethodAccessor49.invoke(Unknown Source)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:483)\n\tat org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)\n\tat org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:151)\n\tat org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:171)\n\tat org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$TypeOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:195)\n\tat org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:104)\n\tat org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:384)\n\tat org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:342)\n\tat org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:101)\n\tat org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:271)\n\tat org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)\n\tat org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)\n\tat org.glassfish.jersey.internal.Errors.process(Errors.java:315)\n\tat org.glassfish.jersey.internal.Errors.process(Errors.java:297)\n\tat org.glassfish.jersey.internal.Errors.process(Errors.java:267)\n\tat org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:297)\n\tat org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:254)\n\tat org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:1030)\n\tat org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:373)\n\tat org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:381)\n\tat org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:344)\n\tat org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:221)\n\tat org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:717)\n\tat org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:552)\n\tat org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1125)\n\tat org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:479)\n\tat org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1059)\n\tat org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)\n\tat org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)\n\tat org.eclipse.jetty.server.Server.handle(Server.java:497)\n\tat org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)\n\tat org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:248)\n\tat org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)\n\tat org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:610)\n\tat org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:539)\n\tat java.lang.Thread.run(Thread.java:745)\n"}

### after
$ td connector:guess config/error_seed.yml
Error: 422: BulkLoad configuration guess failed: No input files to read sample data
```