### PR TITLE
pct-encode for both URL and Forms

### DIFF
--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -638,14 +638,22 @@ private
   if ''.respond_to?(:encode)
     # @param [String] s
     # @return [String]
+    # * ' ' and '+' must be escaped into %20 and %2B because escaped text may be
+    #   used as both URI and query.
+    # * '.' must be escaped as %2E because it may be cunfused with extension.
     def e(s)
-      CGI.escape(s.to_s.encode("UTF-8"))
+      s = s.to_s.encode(Encoding::UTF_8).force_encoding(Encoding::ASCII_8BIT)
+      s.gsub!(/[^\-_!~*'()~0-9A-Z_a-z]/){|x|'%%%02X' % x.ord}
+      s
     end
   else
     # @param [String] s
     # @return [String]
+    # * ' ' and '+' must be escaped into %20 and %2B because escaped text may be
+    #   used as both URI and query.
+    # * '.' must be escaped as %2E because it may be cunfused with extension.
     def e(s)
-      CGI.escape(s.to_s)
+      s.to_s.gsub(/[^\-_!~*'()~0-9A-Z_a-z]/){|x|'%%%02X' % x.ord}
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,6 @@ shared_context 'common helper' do
   end
 
   def e(s)
-    require 'cgi'
-    CGI.escape(s.to_s)
+    s.to_s.gsub(/[^*\-0-9A-Z_a-z]/){|x|'%%%02X' % x.ord}
   end
 end

--- a/spec/td/client/spec_resources.rb
+++ b/spec/td/client/spec_resources.rb
@@ -15,7 +15,7 @@ shared_context 'spec symbols' do
   end
 
   let :sched_name do
-    'sched_test'
+    'sched test'
   end
 
   let :result_name do

--- a/spec/td/client/user_api_spec.rb
+++ b/spec/td/client/user_api_spec.rb
@@ -53,8 +53,8 @@ describe 'User API' do
 
     # TODO
     it 'does not escape sp but it must be a bug' do
-      stub_api_request(:post, "/v3/user/add/!++++@%23$%25%5E&*()_+%7C~").to_return(:body => {}.to_json)
-      api.add_user('!    @#$%^&*()_+|~', "org", 'name+suffix@example.com', 'password').should == true
+      stub_api_request(:post, "/v3/user/add/!%20%20%20%20@%23$%25%5E&*()_%2B%7C~%2Ecom").to_return(:body => {}.to_json)
+      api.add_user('!    @#$%^&*()_+|~.com', "org", 'name+suffix@example.com', 'password').should == true
     end
   end
 


### PR DESCRIPTION
pct-encode in lib/td/client/api.rb is used both URL and www-form.
It requires following conditions:
* ' ' and '+' must be escaped into %20 and %2B because escaped text may be
  used as both URI and query.
* '.' must be escaped as %2E because it may be cunfused with extension.

#44 #64 