### PR TITLE
Fix response byte size check for multibyte string

### DIFF
--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -267,7 +267,7 @@ private
         if block
           current_total_chunk_size = 0
           response = client.get(target, params, header) {|res, chunk|
-            current_total_chunk_size += chunk.size
+            current_total_chunk_size += chunk.bytesize
             block.call(res, chunk, current_total_chunk_size)
           }
 

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -278,7 +278,7 @@ private
         else
           response = client.get(target, params, header)
 
-          validate_content_length!(response, response.body.size) if @ssl
+          validate_content_length!(response, response.body.bytesize) if @ssl
         end
 
         status = response.code


### PR DESCRIPTION
String#size returns character count, but `Content-Length` calculated with byte size.
That caused mismatch when response.body contains multibyte. e.g.:

```ruby
[2] pry(main)> "\u00e9"
=> "é"
[3] pry(main)> "\u00e9".size
=> 1
[4] pry(main)> "\u00e9".bytesize
=> 2
```
