### PR TITLE
add msgpack dependency pattern to support JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.0.0
   - 2.1.7
   - 2.2.3
+  - jruby-19mode
+  - jruby-head
   - rbx-2
   - ruby-head
   - ree

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -121,7 +121,12 @@ class API
         record[k] = v.to_s
       end
     }
-    record.to_msgpack(out)
+    if out
+      out << record.to_msgpack
+      out
+    else
+      record.to_msgpack
+    end
   end
 
   # @param [String] target

--- a/td-client.gemspec
+++ b/td-client.gemspec
@@ -17,11 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 1.8.7'
 
-  if RUBY_ENGINE == 'ruby' && RUBY_VERSION.split('.')[0..1].join('.').to_f < 2.2
-    gem.add_dependency "msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "< 0.5.12"]
-  else
-    gem.add_dependency "msgpack", [">= 0.4.4", "!= 0.5.0", "!= 0.5.1", "!= 0.5.2", "!= 0.5.3", "< 0.6.0"]
-  end
+  gem.add_dependency "msgpack", ">= 0.7.3"
   gem.add_dependency "json", ">= 1.7.6"
   gem.add_dependency "httpclient", [">= 2.5.2", "< 2.6.0"]
   gem.add_development_dependency "rspec", "~> 2.8"

--- a/td-client.gemspec
+++ b/td-client.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>= 1.8.7'
 
-  gem.add_dependency "msgpack", ">= 0.7.3"
+  gem.add_dependency "msgpack", "~> 0.7.4"
   gem.add_dependency "json", ">= 1.7.6"
-  gem.add_dependency "httpclient", [">= 2.5.2", "< 2.6.0"]
+  gem.add_dependency "httpclient", "~> 2.7"
   gem.add_development_dependency "rspec", "~> 2.8"
   gem.add_development_dependency 'mime-types', "1.25" # mime-types => 2.0, does not support Ruby 1.8.
   gem.add_development_dependency 'rest-client', "1.6.8" # rest-client => 1.6.8, does not support Ruby 1.8.


### PR DESCRIPTION
There's no dependencies which is not supported on JRuby, except for old msgpack-ruby versions.
Can someone merge this? and release `-java` gem?