### PR TITLE
Support dummy schedule whose `start` is null

### DIFF
--- a/lib/td/client.rb
+++ b/lib/td/client.rb
@@ -356,7 +356,7 @@ class Client
     raise ArgumentError, "'cron' option is required" unless opts[:cron] || opts['cron']
     raise ArgumentError, "'query' option is required" unless opts[:query] || opts['query']
     start = @api.create_schedule(name, opts)
-    return Time.parse(start)
+    return start && Time.parse(start)
   end
 
   # @param [String] name

--- a/lib/td/client/api/schedule.rb
+++ b/lib/td/client/api/schedule.rb
@@ -14,7 +14,7 @@ module Schedule
     if code != "200"
       raise_error("Create schedule failed", res)
     end
-    js = checked_json(body, %w[start])
+    js = checked_json(body)
     return js['start']
   end
 

--- a/spec/td/client/sched_api_spec.rb
+++ b/spec/td/client/sched_api_spec.rb
@@ -23,6 +23,14 @@ describe 'Schedule API' do
       api.create_schedule(sched_name, opts.merge('type' => 'hive')).should == start.to_s
     end
 
+    it 'should create a dummy schedule' do
+      stub_api_request(:post, "/v3/schedule/create/#{e(sched_name)}").
+        with(:body => opts.merge('type' => 'hive')).
+        to_return(:body => {'name' => sched_name, 'start' => nil}.to_json)
+
+      api.create_schedule(sched_name, opts.merge('type' => 'hive')).should be_nil
+    end
+
     it 'should return 422 error with invalid name' do
       name = '1'
       err_msg = "Validation failed: Name is too short" # " (minimum is 3 characters)"

--- a/spec/td/client_sched_spec.rb
+++ b/spec/td/client_sched_spec.rb
@@ -15,6 +15,31 @@ describe 'Schedule Command' do
     client
   end
 
+  describe 'create' do
+    let :opts do
+      {:database => db_name, :cron => '', :type => 'hive', :query => 'select 1;'}
+    end
+
+    before do
+      stub_api_request(:post, "/v3/schedule/create/#{e(sched_name)}").
+      with(:body => opts).
+        to_return(:body => {'name' => sched_name, 'start' => start}.to_json)
+    end
+    context 'start is now' do
+      let (:start){ Time.now.round }
+      it 'returns Time object' do
+        client.create_schedule(sched_name, opts).should == start
+      end
+    end
+
+    context 'start is nil' do
+      let (:start){ nil }
+      it do
+        client.create_schedule(sched_name, opts).should == start
+      end
+    end
+  end
+
   describe 'history' do
     let :opts do
       {'database' => db_name}


### PR DESCRIPTION
Recently td-api supports dummy schedule which intended to be used as
a query storage. This supports such schedule.