### PR TITLE
Use Ruby 2.3 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,4 @@ environment:
     - ruby_version: "193"
     - ruby_version: "21"
     - ruby_version: "22"
+    - ruby_version: "23"


### PR DESCRIPTION
We can use Ruby 2.3 in AppVeyor:
https://github.com/appveyor/ci/issues/734