### PR TITLE
Use Timeout::Error instead of deprecated ::TimeoutError

### DIFF
--- a/lib/td/client/model.rb
+++ b/lib/td/client/model.rb
@@ -416,7 +416,7 @@ class Job < Model
         d = t - t1
         t1 = t
         timeout -= d if d > 0
-        raise ::TimeoutError, "timeout=#{orig_timeout} wait_interval=#{wait_interval}" if timeout <= 0
+        raise Timeout::Error, "timeout=#{orig_timeout} wait_interval=#{wait_interval}" if timeout <= 0
       end
       sleep wait_interval
       yield self if block_given?

--- a/spec/td/client/model_job_spec.rb
+++ b/spec/td/client/model_job_spec.rb
@@ -108,10 +108,10 @@ describe 'Job Model' do
 
     context 'with timeout' do
       context 'the job running time is too long' do
-        it 'raise ::TimeoutError' do
+        it 'raise Timeout::Error' do
           expect {
             job.wait(0.1)
-          }.to raise_error(::TimeoutError)
+          }.to raise_error(Timeout::Error)
         end
       end
 
@@ -121,7 +121,7 @@ describe 'Job Model' do
             thread = Thread.start {
               job.wait(0.3, 0.1, &b)
             }
-            expect{ thread.value }.to raise_error(::TimeoutError)
+            expect{ thread.value }.to raise_error(Timeout::Error)
             expect(thread).to be_stop
           ensure
             thread.kill # just in case


### PR DESCRIPTION
Ruby 2.3 complains that `::TimeoutError` is deprecated:
https://ci.appveyor.com/project/treasure-data/td-client-ruby/build/367/job/nh3ba040ba6fmd0n#L64