### PR TITLE
Drop Ruby 1.9.3 job from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ test_script:
   - bundle exec rake spec
 environment:
   matrix:
-    - ruby_version: "193"
     - ruby_version: "21"
     - ruby_version: "22"
     - ruby_version: "23"


### PR DESCRIPTION
Follows up #90.