### PR TITLE
Don't check max length because of legacy data

### DIFF
--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -184,18 +184,11 @@ class API
   # @param [String] name
   def self.validate_column_name(name)
     target = 'column'
-    min_len = 1
     name = name.to_s
     if name.empty?
       raise ParameterValidationError,
             "Empty #{target} name is not allowed"
     end
-    if name.length < min_len
-      raise ParameterValidationError,
-            "#{target.capitalize} name must be between #{min_len} and #{max_len} characters long. Got #{name.length} " +
-            (name.length == 1 ? "character" : "characters") + "."
-    end
-
     name
   end
 

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -153,7 +153,7 @@ class API
       raise ParameterValidationError,
             "Empty #{target} name is not allowed"
     end
-    if name.length < min_len || name.length > max_len
+    if name.length < min_len || (max_len && name.length > max_len)
       raise ParameterValidationError,
             "#{target.capitalize} name must be between #{min_len} and #{max_len} characters long. Got #{name.length} " +
             (name.length == 1 ? "character" : "characters") + "."
@@ -185,13 +185,12 @@ class API
   def self.validate_column_name(name)
     target = 'column'
     min_len = 1
-    max_len = 255 # current limit is 128 but some user already has 255 length data
     name = name.to_s
     if name.empty?
       raise ParameterValidationError,
             "Empty #{target} name is not allowed"
     end
-    if name.length < min_len || name.length > max_len
+    if name.length < min_len
       raise ParameterValidationError,
             "#{target.capitalize} name must be between #{min_len} and #{max_len} characters long. Got #{name.length} " +
             (name.length == 1 ? "character" : "characters") + "."
@@ -202,7 +201,7 @@ class API
 
   # @param [String] name
   def self.validate_sql_alias_name(name)
-    validate_name("sql_alias", 1, 128, name)
+    validate_name("sql_alias", 1, nil, name)
   end
 
   # @param [String] name

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -149,15 +149,27 @@ class API
     end
 
     name = name.to_s
-    if name.empty?
-      raise ParameterValidationError,
+    if max_len
+      if name.length < min_len || name.length > max_len
+        raise ParameterValidationError,
+          "#{target.capitalize} name must be between #{min_len} and #{max_len} characters long. Got #{name.length} " +
+          (name.length == 1 ? "character" : "characters") + "."
+      end
+    else
+      if min_len == 1
+        if name.empty?
+          raise ParameterValidationError,
             "Empty #{target} name is not allowed"
-    end
-    if name.length < min_len || (max_len && name.length > max_len)
-      raise ParameterValidationError,
-            "#{target.capitalize} name must be between #{min_len} and #{max_len} characters long. Got #{name.length} " +
+        end
+      else
+        if name.length < min_len
+          raise ParameterValidationError,
+            "#{target.capitalize} name must be longer than #{min_len} characters. Got #{name.length} " +
             (name.length == 1 ? "character" : "characters") + "."
+        end
+      end
     end
+
     unless name =~ /^([a-z0-9_]+)$/
       raise ParameterValidationError,
             "#{target.capitalize} name must only consist of lower-case alpha-numeric characters and '_'."

--- a/spec/td/client/api_spec.rb
+++ b/spec/td/client/api_spec.rb
@@ -126,7 +126,7 @@ describe API do
 
     describe "'validate_column_name'" do
       it 'should raise a ParameterValidationError exception' do
-        ['', 'a'*256].each { |ng|
+        [''].each { |ng|
           expect {
             API.validate_column_name(ng)
           }.to raise_error(ParameterValidationError)
@@ -145,7 +145,7 @@ describe API do
 
     describe "'validate_sql_alias_name'" do
       it 'should raise a ParameterValidationError exception' do
-        ['', 'a'*129].each { |ng|
+        [''].each { |ng|
           expect{API.validate_sql_alias_name(ng)}.to raise_error(ParameterValidationError)
         }
         valid = ("a".."z").to_a.join<<("0".."9").to_a.join<<"_"
@@ -159,7 +159,7 @@ describe API do
         VALID_NAMES.each {|ok|
           expect(API.validate_sql_alias_name(ok)).to eq(ok)
         }
-        ['a', '_a', 'a_', 'a'*128].each {|ok|
+        ['a', '_a', 'a_', 'a'*512].each {|ok|
           expect(API.validate_sql_alias_name(ok)).to eq(ok)
         }
       end


### PR DESCRIPTION
On creating, API validates max length.