### PR TITLE
Ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 2.1.10
   - 2.2.5
   - 2.3.1
+  - 2.4.0
   - jruby-19mode
   - jruby-9.0.5.0
   - jruby-head

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -122,13 +122,14 @@ class API
   attr_reader :apikey
 
   MSGPACK_INT64_MAX = 2 ** 64 - 1
+  MSGPACK_INT64_MIN = -1 * (2 ** 63) # it's just same with -2**63, but for readability
 
   # @param [Hash] record
   # @param [IO] out
   def self.normalized_msgpack(record, out = nil)
     record.keys.each { |k|
       v = record[k]
-      if v.kind_of?(Integer) && v > MSGPACK_INT64_MAX
+      if v.kind_of?(Integer) && (v > MSGPACK_INT64_MAX || v < MSGPACK_INT64_MIN)
         record[k] = v.to_s
       end
     }

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -121,12 +121,14 @@ class API
   # @!attribute [r] apikey
   attr_reader :apikey
 
+  MSGPACK_INT64_MAX = 2 ** 64 - 1
+
   # @param [Hash] record
   # @param [IO] out
   def self.normalized_msgpack(record, out = nil)
     record.keys.each { |k|
       v = record[k]
-      if v.kind_of?(Bignum)
+      if v.kind_of?(Integer) && v > MSGPACK_INT64_MAX
         record[k] = v.to_s
       end
     }

--- a/spec/td/client/api_spec.rb
+++ b/spec/td/client/api_spec.rb
@@ -28,14 +28,20 @@ describe API do
       h = {'key' => 1111111111111111111111111111111111}
       unpacked = MessagePack.unpack(API.normalized_msgpack(h))
       expect(unpacked['key']).to eq(h['key'].to_s)
+
+      h = {'key' => -1111111111111111111111111111111111}
+      unpacked = MessagePack.unpack(API.normalized_msgpack(h))
+      expect(unpacked['key']).to eq(h['key'].to_s)
     end
 
     it 'normalized_msgpack with out argument should convert Bignum into String' do
-      h = {'key' => 1111111111111111111111111111111111}
+      h = {'key' => 1111111111111111111111111111111111, 'key2' => -1111111111111111111111111111111111, 'key3' => 0}
       out = ''
       API.normalized_msgpack(h, out)
       unpacked = MessagePack.unpack(out)
       expect(unpacked['key']).to eq(h['key'].to_s)
+      expect(unpacked['key2']).to eq(h['key2'].to_s)
+      expect(unpacked['key3']).to eq(h['key3']) # don't touch non-too-big integer
     end
 
     it 'normalize_database_name should return normalized data' do

--- a/td-client.gemspec
+++ b/td-client.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.1' if RUBY_ENGINE != 'jruby'
 
   gem.add_dependency "msgpack", ">= 0.5.6", "< 2"
-  gem.add_dependency "json", ">= 1.7.6"
   gem.add_dependency "httpclient", ">= 2.7"
   gem.add_development_dependency "rspec", "~> 3.0"
   gem.add_development_dependency 'coveralls'


### PR DESCRIPTION
I found that this library has a problem about Ruby 2.4 Integer unification.
`TreasureData::API.normalized_msgpack` converts all integer values into string on Ruby 2.4.

This change is to fix this problem, and installation problem around json.