### PR TITLE
Handle client errors

### DIFF
--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -636,15 +636,27 @@ private
       klass
     else
       case status_code
-      when "404"
-        NotFoundError
-      when "409"
-        message = "#{message}: conflicts_with job:#{error["details"]["conflicts_with"]}" if error["details"] && error["details"]["conflicts_with"]
-        AlreadyExistsError
+      when "400"
+        BadRequestError
       when "401"
         AuthError
       when "403"
         ForbiddenError
+      when "404"
+        NotFoundError
+      when "405"
+        MethodNotAllowedError
+      when "409"
+        message = "#{message}: conflicts_with job:#{error["details"]["conflicts_with"]}" if error["details"] && error["details"]["conflicts_with"]
+        AlreadyExistsError
+      when "415"
+        UnsupportedMediaTypeError
+      when "422"
+        UnprocessableEntityError
+      when "429"
+        TooManyRequestsError
+      when /\A4\d\d\z/
+        ClientError
       else
         message = "#{status_code}: #{message}"
         APIError

--- a/lib/td/client/api_error.rb
+++ b/lib/td/client/api_error.rb
@@ -13,16 +13,32 @@ class APIError < StandardError
   end
 end
 
-# 401 API errors
-class AuthError < APIError
+# 4xx Client Errors
+class ClientError < APIError
 end
 
-# 403 API errors, used for database permissions
-class ForbiddenError < APIError
+# 400 Bad Request
+class BadRequestError < ClientError
 end
 
-# 409 API errors
-class AlreadyExistsError < APIError
+# 401 Unauthorized
+class AuthError < ClientError
+end
+
+# 403 Forbidden, used for database permissions
+class ForbiddenError < ClientError
+end
+
+# 404 Not Found
+class NotFoundError < ClientError
+end
+
+# 405 Method Not Allowed
+class MethodNotAllowedError < ClientError
+end
+
+# 409 Conflict
+class AlreadyExistsError < ClientError
   attr_reader :conflicts_with
   def initialize(error_message = nil, api_backtrace = nil, conflicts_with=nil)
     super(error_message, api_backtrace)
@@ -30,8 +46,16 @@ class AlreadyExistsError < APIError
   end
 end
 
-# 404 API errors
-class NotFoundError < APIError
+# 415 Unsupported Media Type
+class UnsupportedMediaTypeError < ClientError
+end
+
+# 422 Unprocessable Entity
+class UnprocessableEntityError < ClientError
+end
+
+# 429 Too Many Requests
+class TooManyRequestsError < ClientError
 end
 
 end


### PR DESCRIPTION
Add fine grained exceptions for client errors rather than ignoring them which prevent us from doing intelligent retries when using the library. I didn't had more exceptions since that felt like writing yet another sub-par HTTP library.