### PR TITLE
Make Job created_at value available

### DIFF
--- a/lib/td/client.rb
+++ b/lib/td/client.rb
@@ -203,10 +203,10 @@ class Client
   # @return [Job]
   def jobs(from=nil, to=nil, status=nil, conditions=nil)
     results = @api.list_jobs(from, to, status, conditions)
-    results.map {|job_id, type, status, query, start_at, end_at, cpu_time,
+    results.map {|job_id, type, status, query, created_at, start_at, end_at, cpu_time,
                  result_size, result_url, priority, retry_limit, org, db,
                  duration, num_records|
-      Job.new(self, job_id, type, query, status, nil, nil, start_at, end_at, cpu_time,
+      Job.new(self, job_id, type, query, status, nil, nil, created_at, start_at, end_at, cpu_time,
               result_size, nil, result_url, nil, priority, retry_limit, org, db,
               duration, num_records)
     }
@@ -216,9 +216,9 @@ class Client
   # @return [Job]
   def job(job_id)
     job_id = job_id.to_s
-    type, query, status, url, debug, start_at, end_at, cpu_time,
+    type, query, status, url, debug, created_at, start_at, end_at, cpu_time,
       result_size, result_url, hive_result_schema, priority, retry_limit, org, db, duration, num_records = @api.show_job(job_id)
-    Job.new(self, job_id, type, query, status, url, debug, start_at, end_at, cpu_time,
+    Job.new(self, job_id, type, query, status, url, debug, created_at, start_at, end_at, cpu_time,
             result_size, nil, result_url, hive_result_schema, priority, retry_limit, org, db, duration, num_records)
   end
 
@@ -418,10 +418,10 @@ class Client
   # @return [Array<ScheduledJob>]
   def history(name, from=nil, to=nil)
     result = @api.history(name, from, to)
-    result.map {|scheduled_at,job_id,type,status,query,start_at,end_at,result_url,priority,database|
+    result.map {|scheduled_at,job_id,type,status,query,created_at,start_at,end_at,result_url,priority,database|
       job_param = [job_id, type, query, status,
         nil, nil, # url, debug
-        start_at, end_at,
+        created_at, start_at, end_at,
         nil, # cpu_time
         nil, nil, # result_size, result
         result_url,

--- a/lib/td/client/api/job.rb
+++ b/lib/td/client/api/job.rb
@@ -28,6 +28,7 @@ module Job
       database = m['database']
       status = m['status']
       query = m['query']
+      created_at = m['created_at']
       start_at = m['start_at']
       end_at = m['end_at']
       cpu_time = m['cpu_time']
@@ -37,7 +38,7 @@ module Job
       retry_limit = m['retry_limit']
       duration = m['duration']
       num_records = m['num_records']
-      result << [job_id, type, status, query, start_at, end_at, cpu_time,
+      result << [job_id, type, status, query, created_at, start_at, end_at, cpu_time,
                  result_size, result_url, priority, retry_limit, nil, database,
                  duration, num_records]
     }
@@ -60,6 +61,7 @@ module Job
     status = js['status']
     debug = js['debug']
     url = js['url']
+    created_at = js['created_at']
     start_at = js['start_at']
     end_at = js['end_at']
     cpu_time = js['cpu_time']
@@ -101,7 +103,7 @@ module Job
     end
     priority = js['priority']
     retry_limit = js['retry_limit']
-    return [type, query, status, url, debug, start_at, end_at, cpu_time,
+    return [type, query, status, url, debug, created_at, start_at, end_at, cpu_time,
             result_size, result, hive_result_schema, priority, retry_limit, nil, database, duration, num_records,
             linked_result_export_job_id, result_export_target_job_id]
   end

--- a/lib/td/client/api/schedule.rb
+++ b/lib/td/client/api/schedule.rb
@@ -84,12 +84,13 @@ module Schedule
       database = m['database']
       status = m['status']
       query = m['query']
+      created_at = m['created_at']
       start_at = m['start_at']
       end_at = m['end_at']
       scheduled_at = m['scheduled_at']
       result_url = m['result']
       priority = m['priority']
-      result << [scheduled_at, job_id, type, status, query, start_at, end_at, result_url, priority, database]
+      result << [scheduled_at, job_id, type, status, query, created_at, start_at, end_at, result_url, priority, database]
     }
     return result
   end

--- a/lib/td/client/model.rb
+++ b/lib/td/client/model.rb
@@ -391,6 +391,7 @@ class Job < Model
   # @param [Fixnum] status
   # @param [String] url
   # @param [Boolean] debug
+  # @param [String] created_at
   # @param [String] start_at
   # @param [String] end_at
   # @param [String] cpu_time
@@ -404,9 +405,9 @@ class Job < Model
   # @param [String] db_name
   # @param [Fixnum] duration
   # @param [Fixnum] num_records
-  def initialize(client, job_id, type, query, status=nil, url=nil, debug=nil, start_at=nil, end_at=nil, cpu_time=nil,
-                 result_size=nil, result=nil, result_url=nil, hive_result_schema=nil, priority=nil, retry_limit=nil,
-                 org_name=nil, db_name=nil, duration=nil, num_records=nil)
+  def initialize(client, job_id, type, query, status=nil, url=nil, debug=nil, created_at=nil, start_at=nil,
+                 end_at=nil, cpu_time=nil, result_size=nil, result=nil, result_url=nil, hive_result_schema=nil,
+                 priority=nil, retry_limit=nil, org_name=nil, db_name=nil, duration=nil, num_records=nil)
     super(client)
     @job_id = job_id
     @type = type
@@ -414,6 +415,7 @@ class Job < Model
     @query = query
     @status = status
     @debug = debug
+    @created_at = created_at
     @start_at = start_at
     @end_at = end_at
     @cpu_time = cpu_time
@@ -510,6 +512,12 @@ class Job < Model
   def debug
     update_status! unless @debug || !@auto_update_status || finished?
     @debug
+  end
+
+  # @return [Time, nil]
+  def created_at
+    update_status! unless @created_at || !@auto_update_status || finished?
+    @created_at && !@created_at.empty? ? Time.parse(@created_at) : nil
   end
 
   # @return [Time, nil]
@@ -628,13 +636,14 @@ class Job < Model
   end
 
   def update_status!
-    type, query, status, url, debug, start_at, end_at, cpu_time,
+    type, query, status, url, debug, created_at, start_at, end_at, cpu_time,
       result_size, result_url, hive_result_schema, priority, retry_limit,
       org_name, db_name , duration, num_records = @client.api.show_job(@job_id)
     @query = query
     @status = status
     @url = url
     @debug = debug
+    @created_at = created_at
     @start_at = start_at
     @end_at = end_at
     @cpu_time = cpu_time

--- a/spec/td/client/job_api_spec.rb
+++ b/spec/td/client/job_api_spec.rb
@@ -29,13 +29,14 @@ describe 'Job API' do
         stub_api_request(:get, "/v3/job/list", :query => {'from' => '0'}).to_return(:body => {'jobs' => raw_jobs}.to_json)
 
         jobs = api.list_jobs
-        jobs[i..i].map {|job_id, type, status, query, start_at, end_at, cpu_time,
+        jobs[i..i].map {|job_id, type, status, query, created_at, start_at, end_at, cpu_time,
                       result_size, result_url, priority, retry_limit, org, db,
                       duration, num_records, linked_result_export_job_id, result_export_target_job_id|
           expect(job_id).to eq(job['job_id'])
           expect(type).to eq(job['type'])
           expect(status).to eq(job['status'])
           expect(query).to eq(job['query'])
+          expect(created_at).to eq(job['created_at'])
           expect(start_at).to eq(job['start_at'])
           expect(end_at).to eq(job['end_at'])
           expect(cpu_time).to eq(job['cpu_time'])
@@ -76,13 +77,14 @@ describe 'Job API' do
         job = raw_jobs[i]
         stub_api_request(:get, "/v3/job/show/#{e(i)}").to_return(:body => job.to_json)
 
-        type, query, status, url, debug, start_at, end_at, cpu_time,
+        type, query, status, url, debug, created_at, start_at, end_at, cpu_time,
           result_size, result_url, hive_result_schema, priority, retry_limit, org, db, duration, num_records = api.show_job(i)
         expect(type).to eq(job['type'])
         expect(query).to eq(job['query'])
         expect(status).to eq(job['status'])
         expect(url).to eq(job['url'])
         expect(debug).to eq(job['debug'])
+        expect(created_at).to eq(job['created_at'])
         expect(start_at).to eq(job['start_at'])
         expect(end_at).to eq(job['end_at'])
         expect(cpu_time).to eq(job['cpu_time'])

--- a/spec/td/client/model_job_spec.rb
+++ b/spec/td/client/model_job_spec.rb
@@ -23,7 +23,7 @@ describe 'Job Model' do
     let :arguments do
       job_attributes = raw_jobs.first
       [
-        'job_id', 'type', 'query', 'status', 'url', 'debug',
+        'job_id', 'type', 'query', 'status', 'url', 'debug', 'created_at',
         'start_at', 'end_at', 'cpu_time', 'result_size', 'result', 'result_url',
         'hive_result_schema', 'priority', 'retry_limit', 'org_name', 'db_name',
         'duration', 'num_records'
@@ -53,10 +53,11 @@ describe 'Job Model' do
 
     it 'calls API if auto_update_status=true' do
       job.auto_update_status = true
+      now = Time.now.round
       result_job = {
         'job_id' => job_id,
         'status' => 'queued',
-        'created_at' => Time.now,
+        'created_at' => now,
       }
       stub_request(:get, "https://api.treasuredata.com/v3/job/show/#{job_id}").
         to_return(:body => result_job.to_json)
@@ -64,6 +65,7 @@ describe 'Job Model' do
       expect(job.status).to eq "queued"
       expect(job.url).to be_nil
       expect(job.debug).to be_nil
+      expect(job.created_at).to eq now
       expect(job.start_at).to be_nil
       expect(job.end_at).to be_nil
       expect(job.cpu_time).to be_nil
@@ -77,6 +79,7 @@ describe 'Job Model' do
       expect(job.status).to be_nil
       expect(job.url).to be_nil
       expect(job.debug).to be_nil
+      expect(job.created_at).to be_nil
       expect(job.start_at).to be_nil
       expect(job.end_at).to be_nil
       expect(job.cpu_time).to be_nil

--- a/spec/td/client/sched_api_spec.rb
+++ b/spec/td/client/sched_api_spec.rb
@@ -84,7 +84,7 @@ describe 'Schedule API' do
 
   describe 'history' do
     let :history do
-      ['history', 'job_id', 'type', 'database', 'status', 'query', 'start_at', 'end_at', 'result', 'priority'].inject({}) { |r, e|
+      ['history', 'job_id', 'type', 'database', 'status', 'query', 'created_at', 'start_at', 'end_at', 'result', 'priority'].inject({}) { |r, e|
         r[e] = e
         r
       }
@@ -94,7 +94,7 @@ describe 'Schedule API' do
       stub_api_request(:get, "/v3/schedule/history/#{e(sched_name)}").
         with(:query => {'from' => 0, 'to' => 100}).
         to_return(:body => {'history' => [history]}.to_json)
-        expect(api.history(sched_name, 0, 100)).to eq([[nil, 'job_id', :type, 'status', 'query', 'start_at', 'end_at', 'result', 'priority', 'database']])
+        expect(api.history(sched_name, 0, 100)).to eq([[nil, 'job_id', :type, 'status', 'query', 'created_at', 'start_at', 'end_at', 'result', 'priority', 'database']])
     end
   end
 

--- a/spec/td/client_sched_spec.rb
+++ b/spec/td/client_sched_spec.rb
@@ -46,7 +46,7 @@ describe 'Schedule Command' do
     end
 
     let :history do
-      ['history', 'scheduled_at', 'job_id', 'type', 'database', 'status', 'query', 'start_at', 'end_at', 'result', 'priority'].inject({}) { |r, e|
+      ['history', 'scheduled_at', 'job_id', 'type', 'database', 'status', 'query', 'created_at', 'start_at', 'end_at', 'result', 'priority'].inject({}) { |r, e|
         r[e] = e
         r
       }

--- a/spec/td/client_spec.rb
+++ b/spec/td/client_spec.rb
@@ -29,6 +29,7 @@ describe 'Command' do
         expect(job.type).to         eq raw_jobs[i]['type']
         expect(job.status).to       eq raw_jobs[i]['status']
         expect(job.query).to        eq raw_jobs[i]['query']
+        expect(job.created_at).to   eq Time.parse(raw_jobs[i]['created_at'])
         expect(job.start_at).to     eq Time.parse(raw_jobs[i]['start_at'])
         expect(job.end_at).to       eq Time.parse(raw_jobs[i]['end_at'])
         expect(job.cpu_time).to     eq raw_jobs[i]['cpu_time']


### PR DESCRIPTION
Treasure Data REST API returns `created_at` value such as the following:

```
% curl -H "AUTHORIZATION: TD1 ****" "https://api.treasuredata.com/v3/job/show/{job_id}" | jq .

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1758  100  1758    0     0   1744      0  0:00:01  0:00:01 --:--:--  1744
{
  "job_id": "***",
  "cpu_time": 0,
  "created_at": "2021-11-12 09:00:10 UTC",
  "duration": 14,
  "end_at": "2021-11-12 09:00:27 UTC",
  "num_records": 5,
  "result_size": 302,
  "start_at": "2021-11-12 09:00:13 UTC",
   ...
```

However, currently this library doesn't return `created_at` value.
I believe that the value is useful for Treasure Data users because they become to be able to calculate QUEUED time via Ruby program.
In Treasure Data, queued jobs affect user experience since many queued jobs cause the jobs to appear to be running slower. Also, if we realize queued time, we can recognize there are running heavy jobs.

In addition, if td-client-ruby can return `created_at`, TD Toolbelt can also use this value.

Following is a sample response:

```
irb(main):003:0> client = TreasureData::Client.new(apikey)
=>
#<TreasureData::Client:0x00007fd5308ee088
...
irb(main):004:0> job = client.job(job_id)
=>
#<TreasureData::Job:0x00007fd53192d160
...
irb(main):005:0> job.created_at
=> 2021-11-12 09:00:10 UTC
```