### PR TITLE
Use the latest Ruby images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 
 orbs:
-  ruby: circleci/ruby@1.1.2 
-  win: circleci/windows@2.4.0
+  ruby: circleci/ruby@1.2.0
+  win: circleci/windows@2.4.1
 
 
 commands:
@@ -43,32 +43,28 @@ jobs:
 
   ruby_25:
     docker:
-      - image: circleci/ruby:2.5.8-stretch
+      - image: cimg/ruby:2.5.9
     executor: ruby/default
     steps:
       - run-tests-flow
 
   ruby_26:
     docker:
-      - image: circleci/ruby:2.6.6-stretch
+      - image: cimg/ruby:2.6.8
     executor: ruby/default
     steps:
       - run-tests-flow
 
   ruby_27:
     machine:
-      image: ubuntu-1604:202004-01
+      image: cimg/ruby:2.7.4
     steps:
-      - ruby/install:
-          version: '2.7'
       - run-tests-flow
 
   ruby_30:
     machine:
-      image: ubuntu-1604:202004-01
+      image: cimg/ruby:3.0.2
     steps:
-      - ruby/install:
-          version: '3.0'
       - run-tests-flow
 
   win_ruby:
@@ -82,11 +78,11 @@ jobs:
           shell: powershell.exe
           command: gem install bundler
       - run-tests-flow
-  
+
   jruby_latest:
     docker:
       - image: circleci/jruby:latest
-    steps: 
+    steps:
       - run-tests-flow
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,14 +57,14 @@ jobs:
 
   ruby_27:
     docker:
-      image: cimg/ruby:2.7.4
+      - image: cimg/ruby:2.7.4
     executor: ruby/default
     steps:
       - run-tests-flow
 
   ruby_30:
     docker:
-      image: cimg/ruby:3.0.2
+      - image: cimg/ruby:3.0.2
     executor: ruby/default
     steps:
       - run-tests-flow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,14 @@ jobs:
   ruby_27:
     machine:
       image: cimg/ruby:2.7.4
+    executor: ruby/default
     steps:
       - run-tests-flow
 
   ruby_30:
     machine:
       image: cimg/ruby:3.0.2
+    executor: ruby/default
     steps:
       - run-tests-flow
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,14 @@ jobs:
       - run-tests-flow
 
   ruby_27:
-    machine:
+    docker:
       image: cimg/ruby:2.7.4
     executor: ruby/default
     steps:
       - run-tests-flow
 
   ruby_30:
-    machine:
+    docker:
       image: cimg/ruby:3.0.2
     executor: ruby/default
     steps:


### PR DESCRIPTION
In current pull request, the Circle CI test failed to install Ruby:

```
gpg: requesting key D39DC0E3 from hkp server ipv4.pool.sks-keyservers.net
gpg: requesting key 39499BDB from hkp server ipv4.pool.sks-keyservers.net
?: ipv4.pool.sks-keyservers.net: Host not found
gpgkeys: HTTP fetch error 7: couldn't connect: Success
?: ipv4.pool.sks-keyservers.net: Host not found
gpgkeys: HTTP fetch error 7: couldn't connect: Success
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
gpg: keyserver communications error: keyserver unreachable
gpg: keyserver communications error: public key not found
gpg: keyserver receive failed: public key not found
Network error: Unable to receive GPG keys. Will attempt again (1/3)
gpg: requesting key D39DC0E3 from hkp server ipv4.pool.sks-keyservers.net
gpg: requesting key 39499BDB from hkp server ipv4.pool.sks-keyservers.net
?: ipv4.pool.sks-keyservers.net: Host not found
gpgkeys: HTTP fetch error 7: couldn't connect: Success
?: ipv4.pool.sks-keyservers.net: Host not found
gpgkeys: HTTP fetch error 7: couldn't connect: Success
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
gpg: keyserver communications error: keyserver unreachable
gpg: keyserver communications error: public key not found
gpg: keyserver receive failed: public key not found
Network error: Unable to receive GPG keys. Will attempt again (2/3)
gpg: requesting key D39DC0E3 from hkp server ipv4.pool.sks-keyservers.net
gpg: requesting key 39499BDB from hkp server ipv4.pool.sks-keyservers.net
?: ipv4.pool.sks-keyservers.net: Host not found
gpgkeys: HTTP fetch error 7: couldn't connect: Success
?: ipv4.pool.sks-keyservers.net: Host not found
gpgkeys: HTTP fetch error 7: couldn't connect: Success
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
gpg: keyserver communications error: keyserver unreachable
gpg: keyserver communications error: public key not found
gpg: keyserver receive failed: public key not found
Unable to receive GPG keys, FAILING

Exited with code exit status 1
```

I updated Ruby Orb (from 1.1.2 to 1.2.0) and use `cimg/ruby` instead of `circleci/ruby`.
* https://circleci.com/developer/orbs/orb/circleci/ruby#usage-install_ruby
* https://circleci.com/developer/images/image/cimg/ruby