### PR TITLE
Add custom cert and cert verification option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Treasure Data API library for Ruby
+
 [<img src="https://travis-ci.org/treasure-data/td-client-ruby.svg?branch=master" alt="Build Status" />](https://travis-ci.org/treasure-data/td-client-ruby)
 [<img src="https://ci.appveyor.com/api/projects/status/github/treasure-data/td-client-ruby?branch=master&svg=true" alt="Build Status" />](https://ci.appveyor.com/project/treasure-data/td-client-ruby/branch/master)
 [<img src="https://coveralls.io/repos/treasure-data/td-client-ruby/badge.svg?branch=master&service=github" alt="Coverage Status" />](https://coveralls.io/github/treasure-data/td-client-ruby?branch=master)
@@ -18,9 +19,9 @@
 The Client API library constructor supports a number of options that can
 be provided as part of the optional 'opts' hash map to these methods:
 
-* `initialize`(apikey, opts={}) (constructor)
-* `Client.authenticate`(user, password, opts={}) (class method)
-* `Client.server_status`(opts={}) (class method)
+- `initialize`(apikey, opts={}) (constructor)
+- `Client.authenticate`(user, password, opts={}) (class method)
+- `Client.server_status`(opts={}) (class method)
 
 ### Endpoint
 
@@ -73,6 +74,12 @@ E.g.
 
     # the ssl option is ignored in this case
     opts.merge({:endpoint => "https://api.treasuredata.com", :ssl => false})
+
+    # You can disable verification
+    opts.merge({:endpoint => "https://api.treasuredata.com", :verify => false})
+
+    # You can use your own certificate
+    opts.merge({:endpoint => "https://api.treasuredata.com", :verify => "/path/to/cert"})
 
 ### Proxy
 
@@ -149,16 +156,16 @@ to enable retrying for POST requests.
 The client library implements several hooks to enable/disable/trigger special
 behaviors. These hooks are triggered using environment variables:
 
-* Enable debugging mode:
+- Enable debugging mode:
 
-    `$ TD_CLIENT_DEBUG=1`
+  `$ TD_CLIENT_DEBUG=1`
 
   Currently debugging mode consists of:
 
-  * show request and response of `HTTP`/`HTTPS` `GET` REST API calls;
-  * show request of `HTTP`/`HTTPS` `POST`/`PUT` REST API calls.
+  - show request and response of `HTTP`/`HTTPS` `GET` REST API calls;
+  - show request of `HTTP`/`HTTPS` `POST`/`PUT` REST API calls.
 
 ## More Information
 
-  * Copyright: (c) 2011 Treasure Data Inc.
-  * License: Apache License, Version 2.0
+- Copyright: (c) 2011 Treasure Data Inc.
+- License: Apache License, Version 2.0

--- a/examples/walkthrough.rb
+++ b/examples/walkthrough.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << File.dirname(__FILE__)+"../lib"
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 
 require "msgpack"
 require "tempfile"
@@ -9,8 +9,8 @@ require "td-client"
 include TreasureData
 
 class Example
-  def initialize(api_key)
-    @client = Client.new(api_key)
+  def initialize(api_key, opts={})
+    @client = Client.new(api_key, opts)
   end
 
   # Utils
@@ -246,7 +246,7 @@ class Example
   end
 end
 
+options = {:cert_path => ENV["MY_CUSTOM_CERT"]}
 api_key = ENV["TD_API_KEY"] ||= ""
-ex = Example.new(api_key)
-ex.run
-
+ex = Example.new(api_key, opt=options)
+ex.server_status

--- a/examples/walkthrough.rb
+++ b/examples/walkthrough.rb
@@ -246,7 +246,7 @@ class Example
   end
 end
 
-options = {:cert_path => ENV["MY_CUSTOM_CERT"]}
+options = {:verify => ENV["MY_CUSTOM_CERT"]}
 api_key = ENV["TD_API_KEY"] ||= ""
 ex = Example.new(api_key, opt=options)
 ex.server_status

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -74,8 +74,7 @@ class API
     @retry_post_requests = opts[:retry_post_requests] || false
     @retry_delay = opts[:retry_delay] || 5
     @max_cumul_retry_delay = opts[:max_cumul_retry_delay] || 600
-    @cert_path = opts[:cert_path]
-    @skip_cert_verify = opts[:skip_cert_verify] || false
+    @verify = opts[:verify]
 
     case uri.scheme
     when 'http', 'https'
@@ -528,14 +527,12 @@ private
       client.ssl_config.options |= OpenSSL::SSL::OP_NO_SSLv3
     end
 
-    # allow users to use their own custom ca
-    if @cert_path
-      client.ssl_config.add_trust_ca(@cert_path)
-    end
-
-    # overwrite ssl verify_mode to disable cerficate verification
-    if @skip_cert_verify
+    # allow users to use their own custom ca 
+    # or disable verification
+    if @verify == false
       client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    elsif @verify.is_a? String
+      client.ssl_config.add_trust_ca(@verify)
     end
 
     header = {}

--- a/lib/td/client/api.rb
+++ b/lib/td/client/api.rb
@@ -74,6 +74,8 @@ class API
     @retry_post_requests = opts[:retry_post_requests] || false
     @retry_delay = opts[:retry_delay] || 5
     @max_cumul_retry_delay = opts[:max_cumul_retry_delay] || 600
+    @cert_path = opts[:cert_path]
+    @skip_cert_verify = opts[:skip_cert_verify] || false
 
     case uri.scheme
     when 'http', 'https'
@@ -524,6 +526,16 @@ private
       client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_PEER
       # Disable SSLv3 connection in favor of POODLE Attack protection
       client.ssl_config.options |= OpenSSL::SSL::OP_NO_SSLv3
+    end
+
+    # allow users to use their own custom ca
+    if @cert_path
+      client.ssl_config.add_trust_ca(@cert_path)
+    end
+
+    # overwrite ssl verify_mode to disable cerficate verification
+    if @skip_cert_verify
+      client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
 
     header = {}

--- a/spec/td/client/api_ssl_connection_spec.rb
+++ b/spec/td/client/api_ssl_connection_spec.rb
@@ -51,7 +51,7 @@ describe 'API SSL connection' do
     @server = setup_server(:TLSv1_2)
     api = API.new(nil, :endpoint => "https://localhost:#{@serverport}", :retry_post_requests => false, :verify => false)
     expect {
-        api.delete_database('no_such_database') # When openssl does not support SSLv3, httpclient server will not start. For context: https://github.com/nahi/httpclient/pull/424#issuecomment-731714786
+        api.delete_database('no_such_database')
     }.to raise_error TreasureData::NotFoundError
   end
 
@@ -59,7 +59,7 @@ describe 'API SSL connection' do
     @server = setup_server(:TLSv1_2)
     api = API.new(nil, :endpoint => "https://localhost:#{@serverport}", :retry_post_requests => false, :verify => File.join(DIR, 'testRootCA.crt'))
     expect {
-        api.delete_database('no_such_database') # When openssl does not support SSLv3, httpclient server will not start. For context: https://github.com/nahi/httpclient/pull/424#issuecomment-731714786
+        api.delete_database('no_such_database') 
     }.to raise_error TreasureData::NotFoundError
   end
 

--- a/spec/td/client/api_ssl_connection_spec.rb
+++ b/spec/td/client/api_ssl_connection_spec.rb
@@ -55,7 +55,7 @@ describe 'API SSL connection' do
     }.to raise_error TreasureData::NotFoundError
   end
 
-  it 'success to access to the server with self sighed certificate' do
+  it 'should succeed to access to the server with self signed certificate' do
     @server = setup_server(:TLSv1_2)
     api = API.new(nil, :endpoint => "https://localhost:#{@serverport}", :retry_post_requests => false, :verify => File.join(DIR, 'testRootCA.crt'))
     expect {

--- a/spec/td/client/api_ssl_connection_spec.rb
+++ b/spec/td/client/api_ssl_connection_spec.rb
@@ -47,6 +47,22 @@ describe 'API SSL connection' do
     }.to raise_error OpenSSL::SSL::SSLError
   end
 
+  it 'success to access to the server with verify false option' do
+    @server = setup_server(:TLSv1_2)
+    api = API.new(nil, :endpoint => "https://localhost:#{@serverport}", :retry_post_requests => false, :verify => false)
+    expect {
+        api.delete_database('no_such_database') # When openssl does not support SSLv3, httpclient server will not start. For context: https://github.com/nahi/httpclient/pull/424#issuecomment-731714786
+    }.to raise_error TreasureData::NotFoundError
+  end
+
+  it 'success to access to the server with self sighed certificate' do
+    @server = setup_server(:TLSv1_2)
+    api = API.new(nil, :endpoint => "https://localhost:#{@serverport}", :retry_post_requests => false, :verify => File.join(DIR, 'testRootCA.crt'))
+    expect {
+        api.delete_database('no_such_database') # When openssl does not support SSLv3, httpclient server will not start. For context: https://github.com/nahi/httpclient/pull/424#issuecomment-731714786
+    }.to raise_error TreasureData::NotFoundError
+  end
+
   it 'should success to connect TLSv1_2 only server' do
     @server = setup_server(:TLSv1_2)
     api = API.new(nil, :endpoint => "https://localhost:#{@serverport}", :retry_post_requests => false)

--- a/spec/td/client/api_ssl_connection_spec.rb
+++ b/spec/td/client/api_ssl_connection_spec.rb
@@ -47,7 +47,7 @@ describe 'API SSL connection' do
     }.to raise_error OpenSSL::SSL::SSLError
   end
 
-  it 'success to access to the server with verify false option' do
+  it 'should succeed to access to the server with verify false option' do
     @server = setup_server(:TLSv1_2)
     api = API.new(nil, :endpoint => "https://localhost:#{@serverport}", :retry_post_requests => false, :verify => false)
     expect {


### PR DESCRIPTION
## Purpose
Unfortunately, there is no certification option for td-client-ruby.
This is incovenient when users need to work within the network that Proxy or VPN uses its own custom CAs.
To resolve this problem, I added two options.

1. cert_path => this is for letting httpclient read custom root CA
2. skip_cert_verify => this is for letting httpclient ignore certificate verification

And also fixed walkthrogh.rb to read library correctly.
